### PR TITLE
Training session crud operations

### DIFF
--- a/backend/src/main/java/com/trainerlog/controller/ClientExerciseController.java
+++ b/backend/src/main/java/com/trainerlog/controller/ClientExerciseController.java
@@ -5,14 +5,11 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.trainerlog.dto.client_exercise.ClientExerciseRequestDto;
 import com.trainerlog.dto.client_exercise.ClientExerciseResponseDto;
-import com.trainerlog.security.CustomUserPrincipal;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -21,7 +18,7 @@ import com.trainerlog.service.client_exercise.ClientExerciseService;
 import com.trainerlog.validation.ValidationGroups;
 import java.util.List;
 import jakarta.validation.Valid;
-
+import com.trainerlog.util.SecurityUtil;
 @RestController
 @RequestMapping("/api/client_exercises")
 @AllArgsConstructor
@@ -30,39 +27,35 @@ public class ClientExerciseController {
 
     private final ClientExerciseService clientExerciseService;
 
-    private UUID getAuthorizedTrainerId() {
-        Authentication authorization = SecurityContextHolder.getContext().getAuthentication();
-        CustomUserPrincipal user = (CustomUserPrincipal) authorization.getPrincipal();
-        return user.getId();
-    }
+  
 
     @PostMapping("/create")
     public ClientExerciseResponseDto createClientExercise(@Valid @RequestBody ClientExerciseRequestDto clientExercise) {
-        UUID trainerId = getAuthorizedTrainerId();
+        UUID trainerId =  SecurityUtil.getAuthorizedTrainerId();
         return clientExerciseService.createClientExercise(clientExercise, trainerId);
     }
 
     @PutMapping("/update/{id}")
     public ClientExerciseResponseDto updateClientExercise(@PathVariable UUID id, @Validated(ValidationGroups.Update.class) @RequestBody ClientExerciseRequestDto clientExercise) {
-        UUID trainerId = getAuthorizedTrainerId();
+        UUID trainerId =  SecurityUtil.getAuthorizedTrainerId();
         return clientExerciseService.updateClientExercise(id, clientExercise, trainerId);
     }
     @DeleteMapping("/delete/{id}")
     public void deleteClientExercise(@PathVariable UUID id, @RequestParam UUID clientId) {
-        UUID trainerId = getAuthorizedTrainerId();
+        UUID trainerId =  SecurityUtil.getAuthorizedTrainerId();
         clientExerciseService.deleteClientExercise(id, trainerId, clientId);
     }
 
     // get all client exercises for a specific client
     @GetMapping("/all")
     public List<ClientExerciseResponseDto> getAllClientExercises(@RequestParam UUID clientId) {
-        UUID trainerId = getAuthorizedTrainerId();
+        UUID trainerId =  SecurityUtil.getAuthorizedTrainerId();
         return clientExerciseService.getAllClientExercises(clientId, trainerId);
     }
 
     @GetMapping("/{id}")
     public ClientExerciseResponseDto getClientExerciseById(@PathVariable UUID id, @RequestParam UUID clientId) {
-        UUID trainerId = getAuthorizedTrainerId();
+        UUID trainerId =  SecurityUtil.getAuthorizedTrainerId();
         return clientExerciseService.getClientExerciseById(id, clientId, trainerId);
     }
 

--- a/backend/src/main/java/com/trainerlog/controller/ExerciseController.java
+++ b/backend/src/main/java/com/trainerlog/controller/ExerciseController.java
@@ -21,6 +21,8 @@ import com.trainerlog.dto.exercise.ExerciseResponseDto;
 import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.RequestBody;
 import com.trainerlog.service.exercise.ExerciseService;
+import com.trainerlog.util.SecurityUtil;
+
 import java.util.List;
 
 @RestController
@@ -31,33 +33,26 @@ public class ExerciseController {
 
     private final ExerciseService exerciseService;
 
-        // Authentication method to get the current trainer's ID
-    private UUID getAuthorizedTrainerId() {
-        Authentication authorization = SecurityContextHolder.getContext().getAuthentication();
-        CustomUserPrincipal user = (CustomUserPrincipal) authorization.getPrincipal();
-        return user.getId();
-    }
-
     @PostMapping("/create")
     public ExerciseResponseDto createExercise(@Valid @RequestBody ExerciseRequestDto dto) {
-        UUID trainerId = getAuthorizedTrainerId();
+        UUID trainerId = SecurityUtil.getAuthorizedTrainerId();
         return exerciseService.createExercise(dto, trainerId);
     }
     @PutMapping("/update/{id}")
     public ExerciseResponseDto updateExercise(@PathVariable UUID id, @Valid @RequestBody ExerciseRequestDto dto) {
-        UUID trainerId = getAuthorizedTrainerId();
+        UUID trainerId = SecurityUtil.getAuthorizedTrainerId();
         return exerciseService.updateExercise(id, dto, trainerId);
     }
 
     @DeleteMapping("/delete/{id}")
     public void deleteExercise(@PathVariable UUID id) {
-        UUID trainerId = getAuthorizedTrainerId();
+        UUID trainerId = SecurityUtil.getAuthorizedTrainerId();
         exerciseService.deleteExercise(id, trainerId);
     }   
 
     @GetMapping("/all")
     public List<ExerciseResponseDto> getAllExercises() {
-        UUID trainerId = getAuthorizedTrainerId();
+        UUID trainerId = SecurityUtil.getAuthorizedTrainerId();
         return exerciseService.getAllExercises(trainerId);
     }
 

--- a/backend/src/main/java/com/trainerlog/controller/TrainingSessionController.java
+++ b/backend/src/main/java/com/trainerlog/controller/TrainingSessionController.java
@@ -1,0 +1,58 @@
+package com.trainerlog.controller;
+import lombok.AllArgsConstructor;
+
+import java.util.UUID;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.trainerlog.dto.training_session.TrainingSessionRequestDto;
+import com.trainerlog.dto.training_session.TrainingSessionResponseDto;
+import com.trainerlog.util.SecurityUtil;
+import com.trainerlog.service.training_session.TrainingSessionService;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import java.util.List;
+@RestController
+@AllArgsConstructor
+@RequestMapping("/api/training-sessions")
+public class TrainingSessionController {
+
+    private final TrainingSessionService trainingSessionService;
+
+    
+    @PostMapping("/create")
+    public TrainingSessionResponseDto createTrainingSession(@Valid @RequestBody TrainingSessionRequestDto trainingSessionRequestDto) {
+        UUID trainerId = SecurityUtil.getAuthorizedTrainerId();
+        return trainingSessionService.createTrainingSession(trainingSessionRequestDto, trainerId);
+
+    }
+    @PutMapping("/update/{sessionId}")
+    public TrainingSessionResponseDto updateTrainingSession(@Valid @RequestBody TrainingSessionRequestDto trainingSessionRequestDto, 
+                                                            @PathVariable UUID sessionId) {
+        UUID trainerId = SecurityUtil.getAuthorizedTrainerId();
+        return trainingSessionService.updateTrainingSession(trainingSessionRequestDto, trainerId, sessionId);
+    }
+    @DeleteMapping("/delete/{sessionId}")
+    public void deleteTrainingSession(@PathVariable UUID sessionId, @RequestParam UUID clientId) {
+        UUID trainerId = SecurityUtil.getAuthorizedTrainerId();
+        trainingSessionService.deleteTrainingSession(clientId, trainerId, sessionId);
+    }
+    @GetMapping("/{sessionId}")
+    public TrainingSessionResponseDto getTrainingSessionById(@PathVariable UUID sessionId, @RequestParam UUID clientId) {
+        UUID trainerId = SecurityUtil.getAuthorizedTrainerId();
+        return trainingSessionService.getTrainingSessionById(sessionId, clientId, trainerId);
+    }
+    @GetMapping("/all")
+    public List<TrainingSessionResponseDto> getAllTrainingSessions(@RequestParam UUID clientId) {
+        UUID trainerId = SecurityUtil.getAuthorizedTrainerId();
+        return trainingSessionService.getAllTrainingSessions(clientId, trainerId);
+    }
+
+}

--- a/backend/src/main/java/com/trainerlog/controller/UserController.java
+++ b/backend/src/main/java/com/trainerlog/controller/UserController.java
@@ -10,11 +10,10 @@ import com.trainerlog.dto.user.UserResponseDto;
 
 import jakarta.validation.Valid;
 
-import org.springframework.security.core.Authentication;
 import java.util.List;
 import java.util.UUID;
-import com.trainerlog.security.CustomUserPrincipal;
 import com.trainerlog.service.user.UserService;
+import com.trainerlog.util.SecurityUtil;
 
 @RestController
 @AllArgsConstructor
@@ -23,41 +22,34 @@ public class UserController {
 
     private final UserService userService;
 
-
-    // Authentication method to get the current trainer's ID
-    private UUID getAuthorizedTrainerId() {
-        Authentication authorization = SecurityContextHolder.getContext().getAuthentication();
-        CustomUserPrincipal user = (CustomUserPrincipal) authorization.getPrincipal();
-        return user.getId();
-    }
-
     @PostMapping("/create") // Endpoint for creating a new use
     public UserResponseDto createUser(@Valid @RequestBody UserRequestDto dto) {
-        return userService.createUser(dto, getAuthorizedTrainerId());
+        UUID trainerId = SecurityUtil.getAuthorizedTrainerId();
+        return userService.createUser(dto, trainerId);
     }
 
     @PutMapping("/update/{id}")
     public UserResponseDto updateUser(@PathVariable UUID id, @RequestBody UserRequestDto dto) {
-            UUID trainerId = getAuthorizedTrainerId(); 
+            UUID trainerId = SecurityUtil.getAuthorizedTrainerId();
         return userService.updateUser(id, dto, trainerId);
     }
 
      @DeleteMapping("/delete/{id}")
     public void deleteUser(@PathVariable UUID id) {
-        UUID trainerId = getAuthorizedTrainerId(); 
+        UUID trainerId = SecurityUtil.getAuthorizedTrainerId();
         userService.deleteUser(id, trainerId);
     }
 
     @GetMapping("/{id}")
     public UserResponseDto getUserById(@PathVariable UUID id) {
-        UUID trainerId = getAuthorizedTrainerId(); 
+        UUID trainerId = SecurityUtil.getAuthorizedTrainerId(); 
         return userService.getUserById(id, trainerId);
     }
 
     // Endpoint to get all clients of the current trainer
     @GetMapping("/me/clients") 
     public List<ClientDto> getClientsOfTrainer() {
-        UUID trainerId = getAuthorizedTrainerId(); 
+        UUID trainerId = SecurityUtil.getAuthorizedTrainerId();
         return userService.getAllClientsForTrainer(trainerId);
     }
 }

--- a/backend/src/main/java/com/trainerlog/dto/client_exercise/ClientExerciseResponseDto.java
+++ b/backend/src/main/java/com/trainerlog/dto/client_exercise/ClientExerciseResponseDto.java
@@ -1,14 +1,11 @@
 package com.trainerlog.dto.client_exercise;
 import lombok.Data;
-import lombok.NoArgsConstructor;
 import java.util.UUID;
 import jakarta.validation.constraints.NotNull;
 import com.trainerlog.model.ClientExercise;
 
 
 @Data
-@NoArgsConstructor
-
 public class ClientExerciseResponseDto {
 
     private UUID id;

--- a/backend/src/main/java/com/trainerlog/dto/exercise/ExerciseResponseDto.java
+++ b/backend/src/main/java/com/trainerlog/dto/exercise/ExerciseResponseDto.java
@@ -4,10 +4,8 @@ package com.trainerlog.dto.exercise;
 import com.trainerlog.model.Exercise;
 
 import lombok.Data;
-import lombok.NoArgsConstructor;
 
 @Data
-@NoArgsConstructor
 public class ExerciseResponseDto {
     private String id;
     private String name;

--- a/backend/src/main/java/com/trainerlog/dto/training_session/TrainingSessionRequestDto.java
+++ b/backend/src/main/java/com/trainerlog/dto/training_session/TrainingSessionRequestDto.java
@@ -1,0 +1,18 @@
+package com.trainerlog.dto.training_session;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import jakarta.validation.constraints.NotNull;
+
+
+@Data
+@NoArgsConstructor
+public class TrainingSessionRequestDto {
+     
+    @NotNull
+    private UUID clientId;
+    private LocalDateTime date;
+
+}

--- a/backend/src/main/java/com/trainerlog/dto/training_session/TrainingSessionResponseDto.java
+++ b/backend/src/main/java/com/trainerlog/dto/training_session/TrainingSessionResponseDto.java
@@ -1,0 +1,29 @@
+package com.trainerlog.dto.training_session;
+import com.trainerlog.model.TrainingSession;
+import java.time.LocalDateTime;
+
+import lombok.Data;
+
+@Data
+public class TrainingSessionResponseDto {
+
+    private String id;
+    private String clientId;
+    private LocalDateTime date;
+
+    public TrainingSessionResponseDto(String id, String clientId, LocalDateTime date) {
+        this.id = id;
+        this.clientId = clientId;
+        this.date = date;
+    }
+
+    public static TrainingSessionResponseDto fromEntity(TrainingSession trainingSession) {
+        return new TrainingSessionResponseDto(
+                trainingSession.getId().toString(),
+                trainingSession.getClient().getId().toString(),
+                trainingSession.getDate()
+        );
+    }
+
+    
+}

--- a/backend/src/main/java/com/trainerlog/model/SessionExercise.java
+++ b/backend/src/main/java/com/trainerlog/model/SessionExercise.java
@@ -23,8 +23,9 @@ public class SessionExercise {
     @ManyToOne
     private ClientExercise clientExercise;
 
-    private Integer sets;
-    private Integer reps;
+    
+    private Integer sets; 
+    private Integer repetitions;
     private Double weight;
 
     // Additional fields can be added as needed, e.g., rest time, notes, etc.

--- a/backend/src/main/java/com/trainerlog/model/TrainingSession.java
+++ b/backend/src/main/java/com/trainerlog/model/TrainingSession.java
@@ -2,10 +2,12 @@ package com.trainerlog.model;
 
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import java.time.LocalDateTime;
 import java.util.*; 
+
 
 
 @Entity
@@ -13,18 +15,21 @@ import java.util.*;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
+@Builder
 public class TrainingSession {
     @Id
     @GeneratedValue
     private UUID id;
 
     private LocalDateTime date;
+ 
 
     @ManyToOne
     @JoinColumn(name = "client_id")
     private User client;
 
-    @OneToMany(mappedBy = "trainingSession", cascade = CascadeType.ALL)
+    //CascadeType.REMOVE - if the training session is deleted, all related session exercises are also delete
+    @OneToMany(mappedBy = "trainingSession", cascade = CascadeType.REMOVE, fetch = FetchType.LAZY) 
     private List<SessionExercise> sessionExercises = new ArrayList<>();
 
 }

--- a/backend/src/main/java/com/trainerlog/repository/TrainingSessionRepository.java
+++ b/backend/src/main/java/com/trainerlog/repository/TrainingSessionRepository.java
@@ -1,0 +1,18 @@
+package com.trainerlog.repository;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.trainerlog.model.TrainingSession;
+
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TrainingSessionRepository extends JpaRepository<TrainingSession, UUID>{
+
+    List<TrainingSession> findAllByClient_Id(UUID clientId);
+
+    
+}

--- a/backend/src/main/java/com/trainerlog/service/exercise/ExerciseServiceImpl.java
+++ b/backend/src/main/java/com/trainerlog/service/exercise/ExerciseServiceImpl.java
@@ -29,6 +29,7 @@ public class ExerciseServiceImpl implements ExerciseService {
 
     @Override
     public ExerciseResponseDto createExercise(ExerciseRequestDto dto, UUID trainerId) {
+        
        log.info("Attempting to create exercise for trainerId={}, name={}", trainerId, dto.getName());
        if (exerciseRepository.existsByNameAndCreatedByTrainer_Id(dto.getName(), trainerId)) {
             log.error("Exercise with name={} already exists for trainerId={}", dto.getName(), trainerId);

--- a/backend/src/main/java/com/trainerlog/service/training_session/TrainingSessionService.java
+++ b/backend/src/main/java/com/trainerlog/service/training_session/TrainingSessionService.java
@@ -1,0 +1,14 @@
+package com.trainerlog.service.training_session;
+
+import java.util.UUID;
+import java.util.List;
+import com.trainerlog.dto.training_session.TrainingSessionRequestDto;
+import com.trainerlog.dto.training_session.TrainingSessionResponseDto;
+
+public interface TrainingSessionService {
+    public TrainingSessionResponseDto createTrainingSession(TrainingSessionRequestDto trainingSessionRequestDto, UUID trainerId);
+    public TrainingSessionResponseDto updateTrainingSession(TrainingSessionRequestDto trainingSessionRequestDto, UUID trainerId, UUID sessionId);
+    public void deleteTrainingSession(UUID clientId, UUID trainerId, UUID sessionId);
+    public TrainingSessionResponseDto getTrainingSessionById(UUID sessionId, UUID clientId, UUID trainerId);
+    public List<TrainingSessionResponseDto> getAllTrainingSessions(UUID clientId, UUID trainerId);
+}

--- a/backend/src/main/java/com/trainerlog/service/training_session/TrainingSessionServiceImpl.java
+++ b/backend/src/main/java/com/trainerlog/service/training_session/TrainingSessionServiceImpl.java
@@ -1,0 +1,181 @@
+package com.trainerlog.service.training_session;
+import lombok.AllArgsConstructor;
+
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+import com.trainerlog.dto.training_session.TrainingSessionRequestDto;
+import com.trainerlog.dto.training_session.TrainingSessionResponseDto;
+import com.trainerlog.model.TrainingSession;
+import com.trainerlog.model.User;
+import com.trainerlog.repository.UserRepository;
+import com.trainerlog.repository.TrainingSessionRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import java.util.List;
+@Service
+@AllArgsConstructor
+public class TrainingSessionServiceImpl implements TrainingSessionService {
+
+    private final UserRepository userRepository;
+    private final TrainingSessionRepository trainingSessionRepository;
+
+    private static final Logger log = LoggerFactory.getLogger(TrainingSessionServiceImpl.class);
+
+       // Helper method to check if the trainer is authorized to manage the client
+    private boolean isTrainerAuthorized(UUID trainerId, User client) {
+        return client.getTrainer() != null && client.getTrainer().getId().equals(trainerId);
+    }
+        //Helper method for gettig Client 
+    private User getClientById(UUID clientId) {
+        return userRepository.findById(clientId)
+                .orElseThrow(() -> {
+                    log.error("Client with id={} not found", clientId);
+                    return new RuntimeException("Client not found");
+                });
+    }
+    private User getAuthorizedClient(UUID clientId, UUID trainerId){
+        User client = getClientById(clientId);
+        if (!isTrainerAuthorized(trainerId, client)) {
+            log.error("Trainer with id={} is not authorized to access client with id={}", trainerId, clientId);
+            throw new RuntimeException("Trainer not authorized to access this client");
+        }
+        return client;
+    }
+
+    // Helper method to retrieve an existing training session by ID
+    private TrainingSession getExistingTrainingSession(UUID sessionId){
+        return trainingSessionRepository.findById(sessionId)
+                .orElseThrow(() -> {
+                    log.error("Training session with id={} not found", sessionId);
+                    return new RuntimeException("Training session not found");
+                });
+
+    }
+    // Helper method to check if the training session belongs to the specified client
+    
+      private TrainingSession getClientTrainingSession(UUID clientId, UUID sessionId) {
+
+        TrainingSession existingTrainingSession = getExistingTrainingSession(sessionId);
+
+         if (!existingTrainingSession.getClient().getId().equals(clientId)) {
+            log.error("Training session with id={} does not belong to client with id={}", sessionId, clientId);
+            throw new RuntimeException("Training session does not belong to the specified client");
+        }
+        return existingTrainingSession;
+      }
+
+
+ 
+    /**
+     * Creates a new training session for a client.
+     *
+     * @param trainingSessionRequestDto The request data for creating the training session
+     * @param trainerId The UUID of the trainer creating the session
+     * @return TrainingSessionResponseDto containing the created training session's information
+     */
+
+    @Override
+    public TrainingSessionResponseDto createTrainingSession (TrainingSessionRequestDto trainingSessionRequestDto, UUID trainerId) {
+        log.info("Attempting to create training session for clientId={}, trainerId={}", trainingSessionRequestDto.getClientId(), trainerId);
+
+        User client = getAuthorizedClient(trainingSessionRequestDto.getClientId(), trainerId);
+
+        TrainingSession newTrainingSession = TrainingSession.builder()
+                .client(client)
+                .date(trainingSessionRequestDto.getDate())
+                .build();
+        log.info("Creating training session for client with id={}", trainingSessionRequestDto.getClientId());
+
+        TrainingSession savedTrainingSession = trainingSessionRepository.save(newTrainingSession);
+        return TrainingSessionResponseDto.fromEntity(savedTrainingSession);
+    }
+
+    /**
+     * Updates an existing training session for a client.
+     *
+     * @param trainingSessionRequestDto The request data for updating the training session
+     * @param trainerId The UUID of the trainer updating the session
+     * @param sessionId The UUID of the training session to update
+     * @return TrainingSessionResponseDto containing the updated training session's information
+     */
+
+    @Override
+    public TrainingSessionResponseDto updateTrainingSession(TrainingSessionRequestDto trainingSessionRequestDto, UUID trainerId, UUID sessionId) {
+        log.info("Attempting to update training session with id={} for trainerId={}", sessionId, trainerId);
+
+        getAuthorizedClient(trainingSessionRequestDto.getClientId(), trainerId);
+
+        TrainingSession existingTrainingSession =  getClientTrainingSession(trainingSessionRequestDto.getClientId(), sessionId);
+
+        // updating the date of the existing training session
+        existingTrainingSession.setDate(trainingSessionRequestDto.getDate());
+
+        return TrainingSessionResponseDto.fromEntity(trainingSessionRepository.save(existingTrainingSession));
+    }
+
+    /**
+     * Deletes a training session for a client.
+     *
+     * @param clientId The UUID of the client whose session is being deleted
+     * @param trainerId The UUID of the trainer performing the deletion
+     * @param sessionId The UUID of the training session to delete
+     */
+
+    @Override
+    public void deleteTrainingSession(UUID clientId, UUID trainerId, UUID sessionId) {
+        log.info("Attempting to delete training session with id={} for clientId={} and trainerId={}", sessionId, clientId, trainerId);
+
+       
+        getAuthorizedClient(clientId, trainerId);
+
+        TrainingSession existingTrainingSession =  getClientTrainingSession(clientId, sessionId);
+
+        trainingSessionRepository.delete(existingTrainingSession);
+    }
+
+    /**
+     * Retrieves a training session by its ID for a specific client and trainer.
+     *
+     * @param sessionId The UUID of the training session to retrieve
+     * @param clientId The UUID of the client whose session is being retrieved
+     * @param trainerId The UUID of the trainer performing the retrieval
+     * @return TrainingSessionResponseDto containing the training session's information
+     */
+
+    @Override
+    public TrainingSessionResponseDto getTrainingSessionById(UUID sessionId, UUID clientId, UUID trainerId) {
+        log.info("Attempting to retrieve training session with id={} for clientId={} and trainerId={}", sessionId, clientId, trainerId);
+
+       
+        getAuthorizedClient(clientId, trainerId);
+
+        TrainingSession existingTrainingSession =  getClientTrainingSession(clientId, sessionId);
+
+        return TrainingSessionResponseDto.fromEntity(existingTrainingSession);
+    }
+
+    /**
+     * Retrieves all training sessions for a specific client and trainer.
+     *
+     * @param clientId The UUID of the client whose sessions are being retrieved
+     * @param trainerId The UUID of the trainer performing the retrieval
+     * @return List of TrainingSessionResponseDto containing all training sessions for the client
+     */
+
+    @Override
+    public List<TrainingSessionResponseDto> getAllTrainingSessions(UUID clientId, UUID trainerId) {
+        log.info("Attempting to retrieve all training sessions for clientId={} and trainerId={}", clientId, trainerId);
+
+        
+        getAuthorizedClient(clientId, trainerId);
+
+
+        List<TrainingSession> trainingSessions = trainingSessionRepository.findAllByClient_Id(clientId);
+        return trainingSessions.stream()
+                .map(TrainingSessionResponseDto::fromEntity)
+                .toList();
+    }
+
+       
+}

--- a/backend/src/main/java/com/trainerlog/util/SecurityUtil.java
+++ b/backend/src/main/java/com/trainerlog/util/SecurityUtil.java
@@ -1,0 +1,22 @@
+package com.trainerlog.util;
+import org.springframework.security.core.Authentication;
+
+import java.util.UUID;
+
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import com.trainerlog.security.CustomUserPrincipal;
+
+public class SecurityUtil {
+
+    private SecurityUtil() {
+        // Private constructor to prevent instantiation
+    }
+
+    public static UUID getAuthorizedTrainerId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        CustomUserPrincipal user = (CustomUserPrincipal) authentication.getPrincipal();
+        return user.getId();
+    }
+    
+}


### PR DESCRIPTION
* Added `TrainingSessionController` to handle CRUD operations for training sessions. 
* Introduced `TrainingSessionService` interface for business logic related to training sessions. 
* Created `TrainingSessionRepository` for database operations related to training sessions. 
* Updated `SessionExercise` model: renamed `reps` to `repetitions` for clarity. 
* Added new DTOs: `TrainingSessionRequestDto` and `TrainingSessionResponseDto`