### PR TITLE
Session Exercise crud operations

### DIFF
--- a/backend/src/main/java/com/trainerlog/controller/ExerciseController.java
+++ b/backend/src/main/java/com/trainerlog/controller/ExerciseController.java
@@ -3,11 +3,6 @@ import lombok.AllArgsConstructor;
 
 import java.util.UUID;
 
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
-
-import com.trainerlog.security.CustomUserPrincipal;
-
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.DeleteMapping;

--- a/backend/src/main/java/com/trainerlog/controller/SessionExerciseController.java
+++ b/backend/src/main/java/com/trainerlog/controller/SessionExerciseController.java
@@ -1,0 +1,55 @@
+package com.trainerlog.controller;
+import lombok.AllArgsConstructor;
+
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import java.util.List;
+import com.trainerlog.dto.session_exercise.SessionExerciseResponseDto;
+import com.trainerlog.service.session_exercise.SessionExerciseService;
+import com.trainerlog.dto.session_exercise.SessionExerciseRequestDto;
+import com.trainerlog.util.SecurityUtil;
+
+import java.util.UUID;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@RestController
+@AllArgsConstructor
+@RequestMapping("/api/session-exercises")
+public class SessionExerciseController {
+
+    private final SessionExerciseService sessionExerciseService;
+
+
+    @PostMapping("/create")
+    public SessionExerciseResponseDto createSessionExercise(@RequestBody SessionExerciseRequestDto sessionExerciseRequestDto) {
+        UUID trainerId = SecurityUtil.getAuthorizedTrainerId();
+        return sessionExerciseService.createSessionExercise(sessionExerciseRequestDto, trainerId);
+    }
+    @PutMapping("/update/{id}")
+    public SessionExerciseResponseDto updateSessionExercise(@PathVariable UUID id ,@RequestBody SessionExerciseRequestDto sessionExerciseRequestDto) {
+        UUID trainerId = SecurityUtil.getAuthorizedTrainerId();
+        return sessionExerciseService.updateSessionExercise(id, sessionExerciseRequestDto, trainerId);
+    }
+    @DeleteMapping("/delete/{id}")
+    public void deleteSessionExercise(@PathVariable UUID id) {
+        UUID trainerId = SecurityUtil.getAuthorizedTrainerId();
+        sessionExerciseService.deleteSessionExercise(id, trainerId);
+    }
+    @GetMapping("/{id}")
+    public SessionExerciseResponseDto getSessionExerciseById(@PathVariable UUID id) {
+        UUID trainerId = SecurityUtil.getAuthorizedTrainerId();
+        return sessionExerciseService.getSessionExerciseById(id, trainerId);
+    }
+    @GetMapping("/all")
+    public List<SessionExerciseResponseDto> getAllSessionExercises(@RequestParam UUID clientId) {
+        UUID trainerId = SecurityUtil.getAuthorizedTrainerId();
+        return sessionExerciseService.getAllSessionExercises(clientId, trainerId);
+    }
+    
+}

--- a/backend/src/main/java/com/trainerlog/controller/UserController.java
+++ b/backend/src/main/java/com/trainerlog/controller/UserController.java
@@ -1,6 +1,5 @@
 package com.trainerlog.controller;
 
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 import lombok.AllArgsConstructor;
 

--- a/backend/src/main/java/com/trainerlog/dto/session_exercise/SessionExerciseRequestDto.java
+++ b/backend/src/main/java/com/trainerlog/dto/session_exercise/SessionExerciseRequestDto.java
@@ -1,0 +1,17 @@
+package com.trainerlog.dto.session_exercise;
+import java.util.UUID;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class SessionExerciseRequestDto {
+
+    private UUID trainingSessionId;
+    private UUID exerciseId;
+    private Integer sets;
+    private Integer repetitions;
+    private Double weight;
+    
+}

--- a/backend/src/main/java/com/trainerlog/dto/session_exercise/SessionExerciseResponseDto.java
+++ b/backend/src/main/java/com/trainerlog/dto/session_exercise/SessionExerciseResponseDto.java
@@ -1,0 +1,41 @@
+
+package com.trainerlog.dto.session_exercise;
+import com.trainerlog.model.SessionExercise;
+import lombok.Data;
+
+@Data
+public class SessionExerciseResponseDto {
+
+    private String id;
+    private String trainingSessionId;
+    private String exerciseId;
+    private String exerciseName;
+    private Integer sets;
+    private Integer repetitions;
+    private Double weight;
+
+    public SessionExerciseResponseDto(String id, String trainingSessionId, String exerciseId, String exerciseName,
+                                      Integer sets, Integer repetitions, Double weight) {
+        this.id = id;
+        this.trainingSessionId = trainingSessionId;
+        this.exerciseId = exerciseId;
+        this.exerciseName = exerciseName;
+        this.sets = sets;
+        this.repetitions = repetitions;
+        this.weight = weight;
+    }
+
+    public static SessionExerciseResponseDto fromEntity(SessionExercise sessionExercise) {
+        return new SessionExerciseResponseDto(
+                sessionExercise.getId().toString(),
+                sessionExercise.getTrainingSession().getId().toString(),
+                sessionExercise.getExercise().getId().toString(),
+                sessionExercise.getExercise().getName(),
+                sessionExercise.getSets(),
+                sessionExercise.getRepetitions(),
+                sessionExercise.getWeight()
+        );
+    }
+
+    
+}

--- a/backend/src/main/java/com/trainerlog/model/SessionExercise.java
+++ b/backend/src/main/java/com/trainerlog/model/SessionExercise.java
@@ -1,7 +1,10 @@
 package com.trainerlog.model;
 
+import java.util.UUID;
+
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -10,18 +13,19 @@ import lombok.NoArgsConstructor;
 @Entity
 @Table(name = "session_exercises")
 @Data
+@Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class SessionExercise {
     @Id
     @GeneratedValue
-    private Long id;
+    private UUID id;
 
     @ManyToOne
     private TrainingSession trainingSession;
 
     @ManyToOne
-    private ClientExercise clientExercise;
+    private Exercise exercise;
 
     
     private Integer sets; 

--- a/backend/src/main/java/com/trainerlog/model/User.java
+++ b/backend/src/main/java/com/trainerlog/model/User.java
@@ -32,7 +32,7 @@ public class User {
     private Role role;
 
     // client belongs to the trainer -> no serialization back
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "trainer_id")
     // doesn't include trainer id to the response (because of the recusrsion)
     @JsonBackReference

--- a/backend/src/main/java/com/trainerlog/repository/ClientExerciseRepository.java
+++ b/backend/src/main/java/com/trainerlog/repository/ClientExerciseRepository.java
@@ -11,6 +11,5 @@ public interface ClientExerciseRepository extends JpaRepository<ClientExercise, 
 
     ClientExercise findByIdAndClient_Id(UUID id, UUID clientId);
     List<ClientExercise> findAllByClient_Id(UUID clientId);
-
-    
+    boolean existsByClient_IdAndExercise_Id(UUID clientId, UUID exerciseId);
 }

--- a/backend/src/main/java/com/trainerlog/repository/SessionExerciseRepository.java
+++ b/backend/src/main/java/com/trainerlog/repository/SessionExerciseRepository.java
@@ -1,0 +1,17 @@
+package com.trainerlog.repository;
+
+import org.springframework.stereotype.Repository;
+import org.springframework.data.jpa.repository.JpaRepository;
+import com.trainerlog.model.SessionExercise;
+
+import java.util.List;
+import java.util.UUID;
+@Repository
+public interface SessionExerciseRepository extends JpaRepository<SessionExercise, UUID> {
+
+    boolean existsByTrainingSession_IdAndExercise_Id(UUID trainingSessionId, UUID exerciseId);
+    List<SessionExercise> findAllByTrainingSession_Client_Id(UUID clientId);
+    
+    // Additional query methods can be defined here if needed
+ 
+}

--- a/backend/src/main/java/com/trainerlog/service/session_exercise/SessionExerciseService.java
+++ b/backend/src/main/java/com/trainerlog/service/session_exercise/SessionExerciseService.java
@@ -1,0 +1,18 @@
+package com.trainerlog.service.session_exercise;
+import com.trainerlog.dto.session_exercise.SessionExerciseRequestDto;
+import com.trainerlog.dto.session_exercise.SessionExerciseResponseDto;
+import java.util.UUID;
+import java.util.List;
+
+public interface SessionExerciseService { 
+
+    public SessionExerciseResponseDto createSessionExercise( SessionExerciseRequestDto sessionExerciseRequestDto, UUID trainerId);
+    public SessionExerciseResponseDto updateSessionExercise(UUID id, SessionExerciseRequestDto sessionExerciseRequestDto, UUID trainerId);
+    public void deleteSessionExercise(UUID id, UUID trainerId);
+    public SessionExerciseResponseDto getSessionExerciseById(UUID id, UUID trainerId);
+    public List<SessionExerciseResponseDto> getAllSessionExercises(UUID clientId, UUID trainerId);
+   
+  
+
+    
+}

--- a/backend/src/main/java/com/trainerlog/service/session_exercise/SessionExerciseServiceImpl.java
+++ b/backend/src/main/java/com/trainerlog/service/session_exercise/SessionExerciseServiceImpl.java
@@ -1,0 +1,205 @@
+package com.trainerlog.service.session_exercise;
+import com.trainerlog.dto.session_exercise.SessionExerciseRequestDto;
+import com.trainerlog.dto.session_exercise.SessionExerciseResponseDto;
+import com.trainerlog.model.Exercise;
+import com.trainerlog.model.SessionExercise;
+import com.trainerlog.model.TrainingSession;
+import com.trainerlog.model.User;
+import com.trainerlog.repository.TrainingSessionRepository;
+import com.trainerlog.repository.UserRepository;
+import com.trainerlog.repository.ClientExerciseRepository;
+import com.trainerlog.repository.ExerciseRepository;
+import com.trainerlog.repository.SessionExerciseRepository;
+
+import lombok.AllArgsConstructor;
+import java.util.UUID;
+ 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import java.util.List;
+
+@Service
+@AllArgsConstructor
+public class SessionExerciseServiceImpl implements SessionExerciseService {
+
+    
+    private final UserRepository userRepository;
+    private final TrainingSessionRepository trainingSessionRepository;
+    private final ExerciseRepository exerciseRepository;
+    private final SessionExerciseRepository sessionExerciseRepository;
+    private final ClientExerciseRepository clientExerciseRepository;
+    private static final Logger log = LoggerFactory.getLogger(SessionExerciseServiceImpl.class);
+
+
+    // Helper method to check if the trainer is authorized to manage the client
+    private void checkTrainerAuthorization(UUID trainerId, User client) {
+        if (client.getTrainer() == null || !client.getTrainer().getId().equals(trainerId)) {
+        log.error("Trainer with id={} is not authorized for client with id={}", trainerId, client.getId());
+        throw new RuntimeException("Trainer not authorized");
+        }
+    }
+    
+    private TrainingSession getSessionById(UUID sessionId) {
+        return trainingSessionRepository.findById(sessionId)
+                .orElseThrow(() -> {
+                    log.error("Training session with id={} not found", sessionId);
+                    return new RuntimeException("Training session not found");
+                });
+    }
+    private Exercise getExerciseById(UUID exerciseId) {
+        return exerciseRepository.findById(exerciseId)
+                .orElseThrow(() -> {
+                    log.error("Exercise with id={} not found", exerciseId);
+                    return new RuntimeException("Exercise not found");
+                });
+    }
+
+    private SessionExercise getSessionExerciseById(UUID sessionExerciseId) {
+        return sessionExerciseRepository.findById(sessionExerciseId)
+                .orElseThrow(() -> {
+                    log.error("Session exercise with id={} not found", sessionExerciseId);
+                    return new RuntimeException("Session exercise not found");
+                });
+    }
+
+     
+     /**
+     * Creates a new session exercise for a training session.
+     * @param sessionExerciseRequestDto the request DTO containing session exercise details
+     * @param trainerId the ID of the trainer creating the session exercise
+     * @return SessionExerciseResponseDto containing the created session exercise's information
+     */
+    @Override
+    public SessionExerciseResponseDto createSessionExercise(SessionExerciseRequestDto sessionExerciseRequestDto, UUID trainerId) {
+
+        TrainingSession session = getSessionById(sessionExerciseRequestDto.getTrainingSessionId());
+        
+        User client = session.getClient();
+
+        checkTrainerAuthorization(trainerId, client);
+
+        
+    
+        Exercise exercise = getExerciseById(sessionExerciseRequestDto.getExerciseId());
+
+        //Check if  on the list of client's exercises is the exercise with the given id
+        if (!clientExerciseRepository.existsByClient_IdAndExercise_Id(client.getId(), exercise.getId())) {
+            log.error("Exercise with id={} is not in the client's exercise list", exercise.getId());
+            throw new RuntimeException("Exercise not found in client's exercise list");
+        }
+      
+        // Check if some of the training session has the same id and exercise id
+        //Prevents duplicate session exercises for the same training session and exercise
+        if (sessionExerciseRepository.existsByTrainingSession_IdAndExercise_Id(sessionExerciseRequestDto.getTrainingSessionId(), sessionExerciseRequestDto.getExerciseId())) {
+            log.error("Session exercise with training session id={} and exercise id={} already exists", session.getId(), exercise.getId());
+            throw new RuntimeException("Session exercise already exists for this training session and exercise");
+        }
+
+        SessionExercise  sessionExercise = SessionExercise.builder()
+                .trainingSession(session)
+                .exercise(exercise)
+                .sets(sessionExerciseRequestDto.getSets())
+                .repetitions(sessionExerciseRequestDto.getRepetitions())
+                .weight(sessionExerciseRequestDto.getWeight())
+                .build();
+
+        SessionExercise savedSessionExercise = sessionExerciseRepository.save(sessionExercise);
+        log.info("Session exercise created with id={}", savedSessionExercise.getId());
+
+        return SessionExerciseResponseDto.fromEntity(savedSessionExercise);
+    }
+
+    /**
+     * Updates an existing session exercise.
+     * @param id the ID of the session exercise to update
+     * @param sessionExerciseRequestDto the request DTO containing updated session exercise details
+     * @param trainerId the ID of the trainer updating the session exercise
+     * @return SessionExerciseResponseDto containing the updated session exercise's information
+     */
+
+    @Override
+    public SessionExerciseResponseDto updateSessionExercise(UUID id, SessionExerciseRequestDto sessionExerciseRequestDto, UUID trainerId) {
+        
+        SessionExercise sessionExercise = getSessionExerciseById(id);
+        TrainingSession session = sessionExercise.getTrainingSession();
+        User client = session.getClient();
+
+        checkTrainerAuthorization(trainerId, client);
+
+        // Update the fields of the session exercise
+        sessionExercise.setSets(sessionExerciseRequestDto.getSets());
+        sessionExercise.setRepetitions(sessionExerciseRequestDto.getRepetitions());
+        sessionExercise.setWeight(sessionExerciseRequestDto.getWeight());
+
+        SessionExercise updatedSessionExercise = sessionExerciseRepository.save(sessionExercise);
+        log.info("Session exercise updated with id={}", updatedSessionExercise.getId());
+
+        return SessionExerciseResponseDto.fromEntity(updatedSessionExercise);
+    }
+
+    /** 
+     * Deletes a session exercise by its ID.
+     * @param id the ID of the session exercise to delete
+     * @param trainerId the ID of the trainer deleting the session exercise
+     * @throws RuntimeException if the session exercise does not exist or the trainer is not authorized
+     */
+    @Override
+    public void deleteSessionExercise(UUID id, UUID trainerId) {
+        
+        SessionExercise sessionExercise = getSessionExerciseById(id);
+        TrainingSession session = sessionExercise.getTrainingSession();
+        User client = session.getClient();
+
+        checkTrainerAuthorization(trainerId, client);
+
+        sessionExerciseRepository.delete(sessionExercise);
+        log.info("Session exercise deleted with id={}", id);
+    }
+
+    /**
+     * Retrieves a session exercise by its ID.
+     * @param id the ID of the session exercise to retrieve
+     * @param trainerId the ID of the trainer requesting the session exercise
+     * @return SessionExerciseResponseDto containing the session exercise's information
+     * @throws RuntimeException if the session exercise does not exist or the trainer is not authorized
+     */
+    @Override
+    public SessionExerciseResponseDto getSessionExerciseById(UUID id, UUID trainerId) {
+        
+        SessionExercise sessionExercise = getSessionExerciseById(id);
+        TrainingSession session = sessionExercise.getTrainingSession();
+        User client = session.getClient();
+
+        checkTrainerAuthorization(trainerId, client);
+
+        log.info("Session exercise retrieved with id={}", id);
+        return SessionExerciseResponseDto.fromEntity(sessionExercise);
+    }
+
+    /**
+     * Retrieves all session exercises for a specific client.
+     * @param clientId the ID of the client whose session exercises are being retrieved
+     * @param trainerId the ID of the trainer requesting the session exercises
+     * @return List of SessionExerciseResponseDto containing all session exercises for the client
+     * @throws RuntimeException if the client does not exist or the trainer is not authorized
+     */
+    @Override
+    public List<SessionExerciseResponseDto> getAllSessionExercises(UUID clientId, UUID trainerId) {
+        User client = userRepository.findById(clientId)
+                .orElseThrow(() -> {
+                    log.error("Client with id={} not found", clientId);
+                    return new RuntimeException("Client not found");
+                });
+
+        checkTrainerAuthorization(trainerId, client);
+
+        List<SessionExercise> sessionExercises = sessionExerciseRepository.findAllByTrainingSession_Client_Id(clientId);
+        log.info("Retrieved all session exercises for client with id={}", clientId);
+
+        return  sessionExercises.stream()
+                .map(SessionExerciseResponseDto::fromEntity)
+                .toList();
+    }
+    
+}


### PR DESCRIPTION
* Added `SessionExerciseController` to handle endpoints for creating, updating, deleting, and retrieving session exercises. `SessionExerciseService` interface and its implementation `SessionExerciseServiceImpl`. - business logic for session exercise operations
*  `SessionExerciseRepository` to interact with the database for session exercises. 
 `SessionExerciseRequestDto` and `SessionExerciseResponseDto` for handling data transfer
* Modified the `User` model to use `FetchType.LAZY` for the `trainer` relationship to optimize database queries. 